### PR TITLE
[Example PR]基于dash子组件接受父组件透传参数特性重构表单值收集及校验

### DIFF
--- a/feffery_antd_components/AntdForm.py
+++ b/feffery_antd_components/AntdForm.py
@@ -19,9 +19,15 @@ Keyword arguments:
 
 - colon (boolean; default True)
 
+- formValidateStatus (boolean; optional):
+    监听搜集内部表单输入类组件的校验结果.
+
 - helps (dict with strings as keys and values of type a list of or a singular dash component, string or number; optional):
     统一设置内部各AntdFormItem的help值，键为对应AntdFormItem的label值
     优先级低于各AntdFormItem的help值.
+
+- initialValues (dict; optional):
+    设置表单默认值，只有初始化以及重置时生效.
 
 - key (string; optional)
 
@@ -54,14 +60,124 @@ Keyword arguments:
     - prop_name (string; optional):
         Holds which property is loading.
 
+- resetForm (boolean; default False):
+    控制参数，用于重置表单项校验状态（不能重置表单项包裹的组件的值，需要通过回调重置表单项包裹的组件的值），回调设置为True后会自动变为False.
+
+- resetFormClicks (number; default 0):
+    辅助监听表单重置参数.
+
 - style (dict; optional)
+
+- submitForm (boolean; default False):
+    控制参数，用于提交表单时手动搜集表单的校验结果，回调设置为True后会自动变为False.
+
+- submitFormClicks (number; default 0):
+    辅助监听表单提交参数.
+
+- validateMessages (dict; default {    default: 'Field validation error for ${label}',    required: 'Please enter ${label}',    enum: '${label} must be one of [${enum}]',    whitespace: '${label} cannot be a blank character',    date: {        format: '${label} date format is invalid',        parse: '${label} cannot be converted to a date',        invalid: '${label} is an invalid date',    },    types: {        string: typeTemplate,        method: typeTemplate,        array: typeTemplate,        object: typeTemplate,        number: typeTemplate,        date: typeTemplate,        boolean: typeTemplate,        integer: typeTemplate,        float: typeTemplate,        regexp: typeTemplate,        email: typeTemplate,        url: typeTemplate,        hex: typeTemplate,    },    string: {        len: '${label} must be ${len} characters',        min: '${label} must be at least ${min} characters',        max: '${label} must be up to ${max} characters',        range: '${label} must be between ${min}-${max} characters',    },    number: {        len: '${label} must be equal to ${len}',        min: '${label} must be minimum ${min}',        max: '${label} must be maximum ${max}',        range: '${label} must be between ${min}-${max}',    },    array: {        len: 'Must be ${len} ${label}',        min: 'At least ${min} ${label}',        max: 'At most ${max} ${label}',        range: 'The amount of ${label} must be between ${min}-${max}',    },    pattern: {        mismatch: '${label} does not match the pattern ${pattern}',    },}):
+    设置默认的验证提示模板.
+
+    `validateMessages` is a dict with keys:
+
+    - array (dict; optional)
+
+        `array` is a dict with keys:
+
+        - len (string; optional)
+
+        - max (string; optional)
+
+        - min (string; optional)
+
+        - range (string; optional)
+
+    - date (dict; optional)
+
+        `date` is a dict with keys:
+
+        - format (string; optional)
+
+        - invalid (string; optional)
+
+        - parse (string; optional)
+
+    - default (string; optional)
+
+    - enum (string; optional)
+
+    - number (dict; optional)
+
+        `number` is a dict with keys:
+
+        - len (string; optional)
+
+        - max (string; optional)
+
+        - min (string; optional)
+
+        - range (string; optional)
+
+    - pattern (dict; optional)
+
+        `pattern` is a dict with keys:
+
+        - mismatch (string; optional)
+
+    - required (string; optional)
+
+    - string (dict; optional)
+
+        `string` is a dict with keys:
+
+        - len (string; optional)
+
+        - max (string; optional)
+
+        - min (string; optional)
+
+        - range (string; optional)
+
+    - types (dict; optional)
+
+        `types` is a dict with keys:
+
+        - array (string; optional)
+
+        - boolean (string; optional)
+
+        - date (string; optional)
+
+        - email (string; optional)
+
+        - float (string; optional)
+
+        - hex (string; optional)
+
+        - integer (string; optional)
+
+        - method (string; optional)
+
+        - number (string; optional)
+
+        - object (string; optional)
+
+        - regexp (string; optional)
+
+        - string (string; optional)
+
+        - url (string; optional)
+
+    - whitespace (string; optional)
 
 - validateStatuses (dict with strings as keys and values of type a value equal to: 'success', 'warning', 'error', 'validating'; optional):
     统一设置内部各AntdFormItem的validateStatus值，键为对应AntdFormItem的label值
     优先级低于各AntdFormItem的validateStatus值.
 
+- validateTrigger (a value equal to: 'onChange', 'onBlur', 'onFocus' | list of a value equal to: 'onChange', 'onBlur', 'onFocus's; optional):
+    统一设置字段触发验证的时机，可选值有onChange、onBlur、onFocus，默认为onChange.
+
 - values (dict; optional):
-    监听搜集内部表单输入类组件的输入值变化情况.
+    搜集内部表单输入类组件的输入值变化情况.
 
 - wrapperCol (dict; optional)
 
@@ -77,10 +193,10 @@ Keyword arguments:
     _namespace = 'feffery_antd_components'
     _type = 'AntdForm'
     @_explicitize_args
-    def __init__(self, children=None, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, layout=Component.UNDEFINED, labelCol=Component.UNDEFINED, wrapperCol=Component.UNDEFINED, colon=Component.UNDEFINED, labelAlign=Component.UNDEFINED, labelWrap=Component.UNDEFINED, values=Component.UNDEFINED, validateStatuses=Component.UNDEFINED, helps=Component.UNDEFINED, loading_state=Component.UNDEFINED, **kwargs):
-        self._prop_names = ['children', 'id', 'className', 'colon', 'helps', 'key', 'labelAlign', 'labelCol', 'labelWrap', 'layout', 'loading_state', 'style', 'validateStatuses', 'values', 'wrapperCol']
+    def __init__(self, children=None, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, layout=Component.UNDEFINED, labelCol=Component.UNDEFINED, wrapperCol=Component.UNDEFINED, colon=Component.UNDEFINED, labelAlign=Component.UNDEFINED, labelWrap=Component.UNDEFINED, validateMessages=Component.UNDEFINED, validateTrigger=Component.UNDEFINED, values=Component.UNDEFINED, initialValues=Component.UNDEFINED, formValidateStatus=Component.UNDEFINED, submitForm=Component.UNDEFINED, submitFormClicks=Component.UNDEFINED, resetForm=Component.UNDEFINED, resetFormClicks=Component.UNDEFINED, validateStatuses=Component.UNDEFINED, helps=Component.UNDEFINED, loading_state=Component.UNDEFINED, **kwargs):
+        self._prop_names = ['children', 'id', 'className', 'colon', 'formValidateStatus', 'helps', 'initialValues', 'key', 'labelAlign', 'labelCol', 'labelWrap', 'layout', 'loading_state', 'resetForm', 'resetFormClicks', 'style', 'submitForm', 'submitFormClicks', 'validateMessages', 'validateStatuses', 'validateTrigger', 'values', 'wrapperCol']
         self._valid_wildcard_attributes =            []
-        self.available_properties = ['children', 'id', 'className', 'colon', 'helps', 'key', 'labelAlign', 'labelCol', 'labelWrap', 'layout', 'loading_state', 'style', 'validateStatuses', 'values', 'wrapperCol']
+        self.available_properties = ['children', 'id', 'className', 'colon', 'formValidateStatus', 'helps', 'initialValues', 'key', 'labelAlign', 'labelCol', 'labelWrap', 'layout', 'loading_state', 'resetForm', 'resetFormClicks', 'style', 'submitForm', 'submitFormClicks', 'validateMessages', 'validateStatuses', 'validateTrigger', 'values', 'wrapperCol']
         self.available_wildcard_properties =            []
         _explicit_args = kwargs.pop('_explicit_args')
         _locals = locals()

--- a/feffery_antd_components/AntdFormItem.py
+++ b/feffery_antd_components/AntdFormItem.py
@@ -13,36 +13,52 @@ Keyword arguments:
     The content of the tab - will only be displayed if this tab is
     selected.
 
-- id (string; optional)
+- id (string; optional):
+    组件id.
 
-- className (string | dict; optional)
+- className (string | dict; optional):
+    css类名.
 
-- colon (boolean; optional)
+- colon (boolean; optional):
+    配合label参数，表示是否显示label后面的冒号，默认为True.
 
-- extra (a list of or a singular dash component, string or number; optional)
+- extra (a list of or a singular dash component, string or number; optional):
+    设置表单项额外的提示信息.
 
 - hasFeedback (boolean; default False):
     是否配合不同的validateStatus值，呈现对应的状态图标，建议仅用于AntdInput  默认：False.
 
-- help (a list of or a singular dash component, string or number; optional)
+- help (a list of or a singular dash component, string or number; optional):
+    设置与validateStatus状态一致的校验提示信息.
 
-- hidden (boolean; default False)
+- hidden (boolean; default False):
+    设置是否隐藏字段，隐藏后仍然会收集和校验字段，默认为False.
 
-- key (string; optional)
+- initialValue (string | dict; optional):
+    设置子元素默认值，如果与AntdForm的initialValues冲突则以AntdForm为准.
 
-- label (a list of or a singular dash component, string or number; optional)
+- key (string; optional):
+    辅助刷新用唯一标识key值.
 
-- labelAlign (a value equal to: 'left', 'right'; optional)
+- label (a list of or a singular dash component, string or number; optional):
+    设置表单项标签内容.
 
-- labelCol (dict; optional)
+- labelAlign (a value equal to: 'left', 'right'; optional):
+    设置表单项标签文本对齐方式，可选的为'left'与'right'，默认为'right'.
+
+- labelCol (dict; optional):
+    设置表单项标签列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm.
 
     `labelCol` is a dict with keys:
 
-    - flex (string | number; optional)
+    - flex (string | number; optional):
+        同css中的flex属性.
 
-    - offset (number; optional)
+    - offset (number; optional):
+        设置offset平移宽度.
 
-    - span (number; optional)
+    - span (number; optional):
+        设置span宽度.
 
 - loading_state (dict; optional)
 
@@ -57,32 +73,105 @@ Keyword arguments:
     - prop_name (string; optional):
         Holds which property is loading.
 
-- required (boolean; default False)
+- messageVariables (dict; optional):
+    设置默认验证字段的信息.
 
-- style (dict; optional)
+- name (string | number | list of string | numbers; optional):
+    设置字段名，支持数组.
 
-- tooltip (a list of or a singular dash component, string or number; optional)
+- noStyle (boolean; default False):
+    为True时不带样式，作为纯字段控件使用，默认为False.
 
-- validateStatus (a value equal to: 'success', 'warning', 'error', 'validating'; optional)
+- preserve (boolean; default True):
+    设置当字段被删除时是否保留字段值，默认为True.
 
-- wrapperCol (dict; optional)
+- required (boolean; optional):
+    设置是否为标签添加必填*标识，默认为False.
+
+- rules (list of dicts; optional):
+    校验规则，设置字段的校验逻辑.
+
+    `rules` is a list of dicts with keys:
+
+    - defaultField (dict; optional):
+        仅在 type 为 array 类型时有效，用于指定数组元素的校验规则.
+
+    - enum (boolean | number | string | dict | list; optional):
+        是否匹配枚举中的值（需要将 type 设置为 enum）.
+
+    - fields (boolean | number | string | dict | list; optional):
+        仅在 type 为 array 或 object 类型时有效，用于指定子元素的校验规则.
+
+    - len (number; optional):
+        string 类型时为字符串长度；number 类型时为确定数字； array 类型时为数组长度.
+
+    - max (number; optional):
+        必须设置 type：string 类型为字符串最大长度；number 类型时为最大值；array 类型时为数组最大长度.
+
+    - message (string; optional):
+        错误信息，不设置时会通过模板自动生成.
+
+    - min (number; optional):
+        必须设置 type：string 类型为字符串最小长度；number 类型时为最小值；array 类型时为数组最小长度.
+
+    - pattern (string; optional):
+        正则表达式匹配.
+
+    - required (boolean; optional):
+        是否为必选字段.
+
+    - type (a value equal to: 'string', 'number', 'boolean', 'method', 'regexp', 'integer', 'float', 'array', 'object', 'enum', 'date', 'url', 'hex', 'email', 'any'; optional):
+        类型，常见有 string |number |boolean |url | email等.
+
+    - validateTrigger (a value equal to: 'onChange', 'onBlur', 'onFocus' | list of a value equal to: 'onChange', 'onBlur', 'onFocus's; optional):
+        设置触发验证时机，可选值有onChange、onBlur、onFocus，默认为onChange，必须是AntdFormItem的validateTrigger的子集.
+
+    - validator (string; optional):
+        设置自定义校验js函数字符串.
+
+    - warningOnly (boolean; optional):
+        仅警告，不阻塞表单提交.
+
+    - whitespace (boolean; optional):
+        如果字段仅包含空格则校验不通过，只在 type: 'string' 时生效.
+
+- style (dict; optional):
+    自定义css字典.
+
+- tooltip (a list of or a singular dash component, string or number; optional):
+    在label后添加额外tooltip鼠标悬浮提示信息.
+
+- validateStatus (a value equal to: 'success', 'warning', 'error', 'validating'; optional):
+    设置校验状态，不设置时会根据设置的校验规则自动生成.
+
+- validateTrigger (a value equal to: 'onChange', 'onBlur', 'onFocus' | list of a value equal to: 'onChange', 'onBlur', 'onFocus's; optional):
+    设置触发验证时机，可选值有onChange、onBlur、onFocus，默认为onChange.
+
+- valuePropName (string; optional):
+    设置子节点的值的属性，默认为'value'.
+
+- wrapperCol (dict; optional):
+    设置表单项列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm.
 
     `wrapperCol` is a dict with keys:
 
-    - flex (string | number; optional)
+    - flex (string | number; optional):
+        同css中的flex属性.
 
-    - offset (number; optional)
+    - offset (number; optional):
+        设置offset平移宽度.
 
-    - span (number; optional)"""
+    - span (number; optional):
+        设置span宽度."""
     _children_props = ['label', 'tooltip', 'extra', 'help']
     _base_nodes = ['label', 'tooltip', 'extra', 'help', 'children']
     _namespace = 'feffery_antd_components'
     _type = 'AntdFormItem'
     @_explicitize_args
-    def __init__(self, children=None, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, required=Component.UNDEFINED, labelCol=Component.UNDEFINED, colon=Component.UNDEFINED, wrapperCol=Component.UNDEFINED, label=Component.UNDEFINED, labelAlign=Component.UNDEFINED, tooltip=Component.UNDEFINED, extra=Component.UNDEFINED, validateStatus=Component.UNDEFINED, hasFeedback=Component.UNDEFINED, help=Component.UNDEFINED, hidden=Component.UNDEFINED, loading_state=Component.UNDEFINED, **kwargs):
-        self._prop_names = ['children', 'id', 'className', 'colon', 'extra', 'hasFeedback', 'help', 'hidden', 'key', 'label', 'labelAlign', 'labelCol', 'loading_state', 'required', 'style', 'tooltip', 'validateStatus', 'wrapperCol']
+    def __init__(self, children=None, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, required=Component.UNDEFINED, labelCol=Component.UNDEFINED, colon=Component.UNDEFINED, wrapperCol=Component.UNDEFINED, label=Component.UNDEFINED, labelAlign=Component.UNDEFINED, tooltip=Component.UNDEFINED, extra=Component.UNDEFINED, validateStatus=Component.UNDEFINED, hasFeedback=Component.UNDEFINED, help=Component.UNDEFINED, hidden=Component.UNDEFINED, messageVariables=Component.UNDEFINED, noStyle=Component.UNDEFINED, preserve=Component.UNDEFINED, initialValue=Component.UNDEFINED, name=Component.UNDEFINED, rules=Component.UNDEFINED, validateTrigger=Component.UNDEFINED, valuePropName=Component.UNDEFINED, loading_state=Component.UNDEFINED, **kwargs):
+        self._prop_names = ['children', 'id', 'className', 'colon', 'extra', 'hasFeedback', 'help', 'hidden', 'initialValue', 'key', 'label', 'labelAlign', 'labelCol', 'loading_state', 'messageVariables', 'name', 'noStyle', 'preserve', 'required', 'rules', 'style', 'tooltip', 'validateStatus', 'validateTrigger', 'valuePropName', 'wrapperCol']
         self._valid_wildcard_attributes =            []
-        self.available_properties = ['children', 'id', 'className', 'colon', 'extra', 'hasFeedback', 'help', 'hidden', 'key', 'label', 'labelAlign', 'labelCol', 'loading_state', 'required', 'style', 'tooltip', 'validateStatus', 'wrapperCol']
+        self.available_properties = ['children', 'id', 'className', 'colon', 'extra', 'hasFeedback', 'help', 'hidden', 'initialValue', 'key', 'label', 'labelAlign', 'labelCol', 'loading_state', 'messageVariables', 'name', 'noStyle', 'preserve', 'required', 'rules', 'style', 'tooltip', 'validateStatus', 'validateTrigger', 'valuePropName', 'wrapperCol']
         self.available_wildcard_properties =            []
         _explicit_args = kwargs.pop('_explicit_args')
         _locals = locals()

--- a/feffery_antd_components/AntdInput.py
+++ b/feffery_antd_components/AntdInput.py
@@ -29,6 +29,9 @@ Keyword arguments:
 
     - minRows (number; optional)
 
+- batchFormValuesMode (boolean; optional):
+    设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为False.
+
 - batchPropsNames (list of strings; optional)
 
 - batchPropsValues (dict; optional)
@@ -94,9 +97,6 @@ Keyword arguments:
 - nClicksSearch (number; default 0)
 
 - nSubmit (number; default 0)
-
-- name (string; optional):
-    用于在基于AntdForm的表单值自动搜集功能中，充当当前表单项的字段名  缺省时会以id作为字段名.
 
 - passwordUseMd5 (boolean; default False)
 
@@ -165,10 +165,10 @@ Keyword arguments:
     _namespace = 'feffery_antd_components'
     _type = 'AntdInput'
     @_explicitize_args
-    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, styles=Component.UNDEFINED, classNames=Component.UNDEFINED, key=Component.UNDEFINED, name=Component.UNDEFINED, mode=Component.UNDEFINED, autoComplete=Component.UNDEFINED, disabled=Component.UNDEFINED, size=Component.UNDEFINED, bordered=Component.UNDEFINED, variant=Component.UNDEFINED, placeholder=Component.UNDEFINED, value=Component.UNDEFINED, defaultValue=Component.UNDEFINED, md5Value=Component.UNDEFINED, debounceValue=Component.UNDEFINED, passwordUseMd5=Component.UNDEFINED, debounceWait=Component.UNDEFINED, addonBefore=Component.UNDEFINED, addonAfter=Component.UNDEFINED, prefix=Component.UNDEFINED, suffix=Component.UNDEFINED, maxLength=Component.UNDEFINED, showCount=Component.UNDEFINED, countFormat=Component.UNDEFINED, autoSize=Component.UNDEFINED, nSubmit=Component.UNDEFINED, nClicksSearch=Component.UNDEFINED, status=Component.UNDEFINED, allowClear=Component.UNDEFINED, autoFocus=Component.UNDEFINED, readOnly=Component.UNDEFINED, emptyAsNone=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
-        self._prop_names = ['id', 'addonAfter', 'addonBefore', 'allowClear', 'autoComplete', 'autoFocus', 'autoSize', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'classNames', 'countFormat', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'emptyAsNone', 'key', 'loading_state', 'maxLength', 'md5Value', 'mode', 'nClicksSearch', 'nSubmit', 'name', 'passwordUseMd5', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'prefix', 'readOnly', 'showCount', 'size', 'status', 'style', 'styles', 'suffix', 'value', 'variant']
+    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, styles=Component.UNDEFINED, classNames=Component.UNDEFINED, key=Component.UNDEFINED, mode=Component.UNDEFINED, autoComplete=Component.UNDEFINED, disabled=Component.UNDEFINED, size=Component.UNDEFINED, bordered=Component.UNDEFINED, variant=Component.UNDEFINED, placeholder=Component.UNDEFINED, value=Component.UNDEFINED, defaultValue=Component.UNDEFINED, md5Value=Component.UNDEFINED, debounceValue=Component.UNDEFINED, passwordUseMd5=Component.UNDEFINED, debounceWait=Component.UNDEFINED, addonBefore=Component.UNDEFINED, addonAfter=Component.UNDEFINED, prefix=Component.UNDEFINED, suffix=Component.UNDEFINED, maxLength=Component.UNDEFINED, showCount=Component.UNDEFINED, countFormat=Component.UNDEFINED, autoSize=Component.UNDEFINED, nSubmit=Component.UNDEFINED, nClicksSearch=Component.UNDEFINED, status=Component.UNDEFINED, allowClear=Component.UNDEFINED, autoFocus=Component.UNDEFINED, readOnly=Component.UNDEFINED, emptyAsNone=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, batchFormValuesMode=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
+        self._prop_names = ['id', 'addonAfter', 'addonBefore', 'allowClear', 'autoComplete', 'autoFocus', 'autoSize', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'classNames', 'countFormat', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'emptyAsNone', 'key', 'loading_state', 'maxLength', 'md5Value', 'mode', 'nClicksSearch', 'nSubmit', 'passwordUseMd5', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'prefix', 'readOnly', 'showCount', 'size', 'status', 'style', 'styles', 'suffix', 'value', 'variant']
         self._valid_wildcard_attributes =            []
-        self.available_properties = ['id', 'addonAfter', 'addonBefore', 'allowClear', 'autoComplete', 'autoFocus', 'autoSize', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'classNames', 'countFormat', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'emptyAsNone', 'key', 'loading_state', 'maxLength', 'md5Value', 'mode', 'nClicksSearch', 'nSubmit', 'name', 'passwordUseMd5', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'prefix', 'readOnly', 'showCount', 'size', 'status', 'style', 'styles', 'suffix', 'value', 'variant']
+        self.available_properties = ['id', 'addonAfter', 'addonBefore', 'allowClear', 'autoComplete', 'autoFocus', 'autoSize', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'classNames', 'countFormat', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'emptyAsNone', 'key', 'loading_state', 'maxLength', 'md5Value', 'mode', 'nClicksSearch', 'nSubmit', 'passwordUseMd5', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'prefix', 'readOnly', 'showCount', 'size', 'status', 'style', 'styles', 'suffix', 'value', 'variant']
         self.available_wildcard_properties =            []
         _explicit_args = kwargs.pop('_explicit_args')
         _locals = locals()

--- a/feffery_antd_components/AntdInputNumber.py
+++ b/feffery_antd_components/AntdInputNumber.py
@@ -17,6 +17,9 @@ Keyword arguments:
 
 - autoFocus (boolean; default False)
 
+- batchFormValuesMode (boolean; optional):
+    设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为False.
+
 - batchPropsNames (list of strings; optional)
 
 - batchPropsValues (dict; optional)
@@ -58,9 +61,6 @@ Keyword arguments:
 - min (number | string; optional)
 
 - nSubmit (number; default 0)
-
-- name (string; optional):
-    用于在基于AntdForm的表单值自动搜集功能中，充当当前表单项的字段名  缺省时会以id作为字段名.
 
 - persisted_props (list of a value equal to: 'value's; default ['value']):
     Properties whose user interactions will persist after refreshing
@@ -109,10 +109,10 @@ Keyword arguments:
     _namespace = 'feffery_antd_components'
     _type = 'AntdInputNumber'
     @_explicitize_args
-    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, name=Component.UNDEFINED, addonBefore=Component.UNDEFINED, addonAfter=Component.UNDEFINED, autoFocus=Component.UNDEFINED, prefix=Component.UNDEFINED, controls=Component.UNDEFINED, keyboard=Component.UNDEFINED, min=Component.UNDEFINED, max=Component.UNDEFINED, step=Component.UNDEFINED, precision=Component.UNDEFINED, stringMode=Component.UNDEFINED, disabled=Component.UNDEFINED, size=Component.UNDEFINED, bordered=Component.UNDEFINED, variant=Component.UNDEFINED, placeholder=Component.UNDEFINED, value=Component.UNDEFINED, defaultValue=Component.UNDEFINED, debounceValue=Component.UNDEFINED, debounceWait=Component.UNDEFINED, nSubmit=Component.UNDEFINED, status=Component.UNDEFINED, readOnly=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
-        self._prop_names = ['id', 'addonAfter', 'addonBefore', 'autoFocus', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'controls', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'key', 'keyboard', 'loading_state', 'max', 'min', 'nSubmit', 'name', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'precision', 'prefix', 'readOnly', 'size', 'status', 'step', 'stringMode', 'style', 'value', 'variant']
+    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, addonBefore=Component.UNDEFINED, addonAfter=Component.UNDEFINED, autoFocus=Component.UNDEFINED, prefix=Component.UNDEFINED, controls=Component.UNDEFINED, keyboard=Component.UNDEFINED, min=Component.UNDEFINED, max=Component.UNDEFINED, step=Component.UNDEFINED, precision=Component.UNDEFINED, stringMode=Component.UNDEFINED, disabled=Component.UNDEFINED, size=Component.UNDEFINED, bordered=Component.UNDEFINED, variant=Component.UNDEFINED, placeholder=Component.UNDEFINED, value=Component.UNDEFINED, defaultValue=Component.UNDEFINED, debounceValue=Component.UNDEFINED, debounceWait=Component.UNDEFINED, nSubmit=Component.UNDEFINED, status=Component.UNDEFINED, readOnly=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, batchFormValuesMode=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
+        self._prop_names = ['id', 'addonAfter', 'addonBefore', 'autoFocus', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'controls', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'key', 'keyboard', 'loading_state', 'max', 'min', 'nSubmit', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'precision', 'prefix', 'readOnly', 'size', 'status', 'step', 'stringMode', 'style', 'value', 'variant']
         self._valid_wildcard_attributes =            []
-        self.available_properties = ['id', 'addonAfter', 'addonBefore', 'autoFocus', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'controls', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'key', 'keyboard', 'loading_state', 'max', 'min', 'nSubmit', 'name', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'precision', 'prefix', 'readOnly', 'size', 'status', 'step', 'stringMode', 'style', 'value', 'variant']
+        self.available_properties = ['id', 'addonAfter', 'addonBefore', 'autoFocus', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'bordered', 'className', 'controls', 'debounceValue', 'debounceWait', 'defaultValue', 'disabled', 'key', 'keyboard', 'loading_state', 'max', 'min', 'nSubmit', 'persisted_props', 'persistence', 'persistence_type', 'placeholder', 'precision', 'prefix', 'readOnly', 'size', 'status', 'step', 'stringMode', 'style', 'value', 'variant']
         self.available_wildcard_properties =            []
         _explicit_args = kwargs.pop('_explicit_args')
         _locals = locals()

--- a/feffery_antd_components/AntdTransfer.py
+++ b/feffery_antd_components/AntdTransfer.py
@@ -11,6 +11,9 @@ Keyword arguments:
 
 - id (string; optional)
 
+- batchFormValuesMode (boolean; optional):
+    设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为False.
+
 - batchPropsNames (list of strings; optional)
 
 - batchPropsValues (dict; optional)
@@ -106,10 +109,10 @@ Keyword arguments:
     _namespace = 'feffery_antd_components'
     _type = 'AntdTransfer'
     @_explicitize_args
-    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, name=Component.UNDEFINED, locale=Component.UNDEFINED, dataSource=Component.UNDEFINED, selectionsIcon=Component.UNDEFINED, height=Component.UNDEFINED, pagination=Component.UNDEFINED, oneWay=Component.UNDEFINED, operations=Component.UNDEFINED, showSearch=Component.UNDEFINED, optionFilterMode=Component.UNDEFINED, showSelectAll=Component.UNDEFINED, titles=Component.UNDEFINED, targetKeys=Component.UNDEFINED, moveDirection=Component.UNDEFINED, moveKeys=Component.UNDEFINED, disabled=Component.UNDEFINED, status=Component.UNDEFINED, readOnly=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
-        self._prop_names = ['id', 'batchPropsNames', 'batchPropsValues', 'className', 'dataSource', 'disabled', 'height', 'key', 'loading_state', 'locale', 'moveDirection', 'moveKeys', 'name', 'oneWay', 'operations', 'optionFilterMode', 'pagination', 'persisted_props', 'persistence', 'persistence_type', 'readOnly', 'selectionsIcon', 'showSearch', 'showSelectAll', 'status', 'style', 'targetKeys', 'titles']
+    def __init__(self, id=Component.UNDEFINED, className=Component.UNDEFINED, style=Component.UNDEFINED, key=Component.UNDEFINED, name=Component.UNDEFINED, locale=Component.UNDEFINED, dataSource=Component.UNDEFINED, selectionsIcon=Component.UNDEFINED, height=Component.UNDEFINED, pagination=Component.UNDEFINED, oneWay=Component.UNDEFINED, operations=Component.UNDEFINED, showSearch=Component.UNDEFINED, optionFilterMode=Component.UNDEFINED, showSelectAll=Component.UNDEFINED, titles=Component.UNDEFINED, targetKeys=Component.UNDEFINED, moveDirection=Component.UNDEFINED, moveKeys=Component.UNDEFINED, disabled=Component.UNDEFINED, status=Component.UNDEFINED, readOnly=Component.UNDEFINED, batchPropsNames=Component.UNDEFINED, batchPropsValues=Component.UNDEFINED, batchFormValuesMode=Component.UNDEFINED, loading_state=Component.UNDEFINED, persistence=Component.UNDEFINED, persisted_props=Component.UNDEFINED, persistence_type=Component.UNDEFINED, **kwargs):
+        self._prop_names = ['id', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'className', 'dataSource', 'disabled', 'height', 'key', 'loading_state', 'locale', 'moveDirection', 'moveKeys', 'name', 'oneWay', 'operations', 'optionFilterMode', 'pagination', 'persisted_props', 'persistence', 'persistence_type', 'readOnly', 'selectionsIcon', 'showSearch', 'showSelectAll', 'status', 'style', 'targetKeys', 'titles']
         self._valid_wildcard_attributes =            []
-        self.available_properties = ['id', 'batchPropsNames', 'batchPropsValues', 'className', 'dataSource', 'disabled', 'height', 'key', 'loading_state', 'locale', 'moveDirection', 'moveKeys', 'name', 'oneWay', 'operations', 'optionFilterMode', 'pagination', 'persisted_props', 'persistence', 'persistence_type', 'readOnly', 'selectionsIcon', 'showSearch', 'showSelectAll', 'status', 'style', 'targetKeys', 'titles']
+        self.available_properties = ['id', 'batchFormValuesMode', 'batchPropsNames', 'batchPropsValues', 'className', 'dataSource', 'disabled', 'height', 'key', 'loading_state', 'locale', 'moveDirection', 'moveKeys', 'name', 'oneWay', 'operations', 'optionFilterMode', 'pagination', 'persisted_props', 'persistence', 'persistence_type', 'readOnly', 'selectionsIcon', 'showSearch', 'showSelectAll', 'status', 'style', 'targetKeys', 'titles']
         self.available_wildcard_properties =            []
         _explicit_args = kwargs.pop('_explicit_args')
         _locals = locals()

--- a/src/lib/components/dataEntry/AntdCheckbox.react.js
+++ b/src/lib/components/dataEntry/AntdCheckbox.react.js
@@ -28,12 +28,6 @@ AntdCheckbox.propTypes = {
     // 辅助刷新用唯一标识key值
     key: PropTypes.string,
 
-    /**
-     * 用于在基于AntdForm的表单值自动搜集功能中，充当当前表单项的字段名
-     * 缺省时会以id作为字段名
-     */
-    name: PropTypes.string,
-
     // 设置是否禁用组件
     disabled: PropTypes.bool,
 
@@ -58,6 +52,12 @@ AntdCheckbox.propTypes = {
 
     // 打包监听batchPropsNames中定义的属性值变化
     batchPropsValues: PropTypes.object,
+
+    /**
+     * 设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为false
+     */
+    batchFormValuesMode: PropTypes.bool,
+
 
     loading_state: PropTypes.shape({
         /**

--- a/src/lib/components/dataEntry/AntdInput.react.js
+++ b/src/lib/components/dataEntry/AntdInput.react.js
@@ -88,12 +88,6 @@ AntdInput.propTypes = {
     // 辅助刷新用唯一标识key值
     key: PropTypes.string,
 
-    /**
-     * 用于在基于AntdForm的表单值自动搜集功能中，充当当前表单项的字段名
-     * 缺省时会以id作为字段名
-     */
-    name: PropTypes.string,
-
     // 用于设置输入框功能模式类型，可选的有'default'、'search'、'text-area'、'password'，默认为'default'
     mode: PropTypes.oneOf(['default', 'search', 'text-area', 'password']),
 
@@ -196,6 +190,11 @@ AntdInput.propTypes = {
 
     // 打包监听batchPropsNames中定义的属性值变化
     batchPropsValues: PropTypes.object,
+
+    /**
+     * 设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为false
+     */
+    batchFormValuesMode: PropTypes.bool,
 
     loading_state: PropTypes.shape({
         /**

--- a/src/lib/components/dataEntry/AntdInputNumber.react.js
+++ b/src/lib/components/dataEntry/AntdInputNumber.react.js
@@ -28,12 +28,6 @@ AntdInputNumber.propTypes = {
     // 辅助刷新用唯一标识key值
     key: PropTypes.string,
 
-    /**
-     * 用于在基于AntdForm的表单值自动搜集功能中，充当当前表单项的字段名
-     * 缺省时会以id作为字段名
-     */
-    name: PropTypes.string,
-
     // 设置前置标签内容
     addonBefore: PropTypes.node,
 
@@ -133,6 +127,11 @@ AntdInputNumber.propTypes = {
 
     // 打包监听batchPropsNames中定义的属性值变化
     batchPropsValues: PropTypes.object,
+
+    /**
+     * 设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为false
+     */
+    batchFormValuesMode: PropTypes.bool,
 
     loading_state: PropTypes.shape({
         /**

--- a/src/lib/components/dataEntry/AntdTransfer.react.js
+++ b/src/lib/components/dataEntry/AntdTransfer.react.js
@@ -128,6 +128,11 @@ AntdTransfer.propTypes = {
     batchPropsValues: PropTypes.object,
 
     /**
+     * 设置作为表单项时表单值是否开启多值模式，可以监听多个参数，默认为false
+     */
+    batchFormValuesMode: PropTypes.bool,
+
+    /**
      * Dash-assigned callback that should be called to report property changes
      * to Dash, to make them available for callbacks.
      */

--- a/src/lib/components/dataEntry/form/AntdForm.react.js
+++ b/src/lib/components/dataEntry/form/AntdForm.react.js
@@ -77,9 +77,106 @@ AntdForm.propTypes = {
     labelWrap: PropTypes.bool,
 
     /**
-     * 监听搜集内部表单输入类组件的输入值变化情况
+     * 设置默认的验证提示模板
+     */
+    validateMessages: PropTypes.exact({
+        default: PropTypes.string,
+        required: PropTypes.string,
+        enum: PropTypes.string,
+        whitespace: PropTypes.string,
+        date: PropTypes.exact({
+            format: PropTypes.string,
+            parse: PropTypes.string,
+            invalid: PropTypes.string
+        }),
+        types: PropTypes.exact({
+            string: PropTypes.string,
+            method: PropTypes.string,
+            array: PropTypes.string,
+            object: PropTypes.string,
+            number: PropTypes.string,
+            date: PropTypes.string,
+            boolean: PropTypes.string,
+            integer: PropTypes.string,
+            float: PropTypes.string,
+            regexp: PropTypes.string,
+            email: PropTypes.string,
+            url: PropTypes.string,
+            hex: PropTypes.string
+        }),
+        string: PropTypes.exact({
+            len: PropTypes.string,
+            min: PropTypes.string,
+            max: PropTypes.string,
+            range: PropTypes.string
+        }),
+        number: PropTypes.exact({
+            len: PropTypes.string,
+            min: PropTypes.string,
+            max: PropTypes.string,
+            range: PropTypes.string
+        }),
+        array: PropTypes.exact({
+            len: PropTypes.string,
+            min: PropTypes.string,
+            max: PropTypes.string,
+            range: PropTypes.string
+        }),
+        pattern: PropTypes.exact({
+            mismatch: PropTypes.string
+        })
+    }),
+
+    /**
+     * 统一设置字段触发验证的时机，可选值有onChange、onBlur、onFocus，默认为onChange
+     */
+    validateTrigger: PropTypes.oneOfType([
+        PropTypes.oneOf([
+            'onChange',
+            'onBlur',
+            'onFocus'
+        ]),
+        PropTypes.arrayOf(PropTypes.oneOf([
+            'onChange',
+            'onBlur',
+            'onFocus'
+        ]))
+    ]),
+
+    /**
+     * 搜集内部表单输入类组件的输入值变化情况
      */
     values: PropTypes.object,
+
+    /**
+     * 设置表单默认值，只有初始化以及重置时生效
+     */
+    initialValues: PropTypes.object,
+
+    /**
+     * 监听搜集内部表单输入类组件的校验结果
+     */
+    formValidateStatus: PropTypes.bool,
+
+    /**
+     * 控制参数，用于提交表单时手动搜集表单的校验结果，回调设置为true后会自动变为false
+     */
+    submitForm: PropTypes.bool,
+
+    /**
+     * 辅助监听表单提交参数
+     */
+    submitFormClicks: PropTypes.number,
+
+    /**
+     * 控制参数，用于重置表单项校验状态（不能重置表单项包裹的组件的值，需要通过回调重置表单项包裹的组件的值），回调设置为true后会自动变为false
+     */
+    resetForm: PropTypes.bool,
+
+    /**
+     * 辅助监听表单重置参数
+     */
+    resetFormClicks: PropTypes.number,
 
     /**
      * 统一设置内部各AntdFormItem的validateStatus值，键为对应AntdFormItem的label值
@@ -119,12 +216,65 @@ AntdForm.propTypes = {
     setProps: PropTypes.func
 };
 
+const typeTemplate = '${label} is not a valid ${type}';
+
 // 设置默认参数
 AntdForm.defaultProps = {
     layout: 'horizontal',
     colon: true,
     labelAlign: 'right',
-    labelWrap: false
+    labelWrap: false,
+    validateMessages: {
+        default: 'Field validation error for ${label}',
+        required: 'Please enter ${label}',
+        enum: '${label} must be one of [${enum}]',
+        whitespace: '${label} cannot be a blank character',
+        date: {
+            format: '${label} date format is invalid',
+            parse: '${label} cannot be converted to a date',
+            invalid: '${label} is an invalid date',
+        },
+        types: {
+            string: typeTemplate,
+            method: typeTemplate,
+            array: typeTemplate,
+            object: typeTemplate,
+            number: typeTemplate,
+            date: typeTemplate,
+            boolean: typeTemplate,
+            integer: typeTemplate,
+            float: typeTemplate,
+            regexp: typeTemplate,
+            email: typeTemplate,
+            url: typeTemplate,
+            hex: typeTemplate,
+        },
+        string: {
+            len: '${label} must be ${len} characters',
+            min: '${label} must be at least ${min} characters',
+            max: '${label} must be up to ${max} characters',
+            range: '${label} must be between ${min}-${max} characters',
+        },
+        number: {
+            len: '${label} must be equal to ${len}',
+            min: '${label} must be minimum ${min}',
+            max: '${label} must be maximum ${max}',
+            range: '${label} must be between ${min}-${max}',
+        },
+        array: {
+            len: 'Must be ${len} ${label}',
+            min: 'At least ${min} ${label}',
+            max: 'At most ${max} ${label}',
+            range: 'The amount of ${label} must be between ${min}-${max}',
+        },
+        pattern: {
+            mismatch: '${label} does not match the pattern ${pattern}',
+        },
+    },
+    submitForm: false,
+    submitFormClicks: 0,
+    resetForm: false,
+    resetFormClicks: 0
 }
 
 export default AntdForm;

--- a/src/lib/components/dataEntry/form/AntdFormItem.react.js
+++ b/src/lib/components/dataEntry/form/AntdFormItem.react.js
@@ -13,7 +13,9 @@ const AntdFormItem = (props) => {
 
 // 定义参数或属性
 AntdFormItem.propTypes = {
-    // 组件id
+    /**
+     * 组件id
+     */
     id: PropTypes.string,
 
     /**
@@ -21,67 +23,103 @@ AntdFormItem.propTypes = {
      */
     children: PropTypes.node,
 
-    // css类名
+    /**
+     * css类名
+     */
     className: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.object
     ]),
 
-    // 自定义css字典
+    /**
+     * 自定义css字典
+     */
     style: PropTypes.object,
 
-    // 辅助刷新用唯一标识key值
+    /**
+     * 辅助刷新用唯一标识key值
+     */
     key: PropTypes.string,
 
-    // 设置是否为标签添加必填*标识，默认为false
+    /**
+     * 设置是否为标签添加必填*标识，默认为false
+     */
     required: PropTypes.bool,
 
-    // 设置表单项标签列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm
+    /**
+     * 设置表单项标签列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm
+     */
     labelCol: PropTypes.exact({
-        // 设置span宽度
+        /**
+         * 设置span宽度
+         */
         span: PropTypes.number,
 
-        // 设置offset平移宽度
+        /**
+         * 设置offset平移宽度
+         */
         offset: PropTypes.number,
 
-        // 同css中的flex属性
+        /**
+         * 同css中的flex属性
+         */
         flex: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.number
         ])
     }),
 
-    // 配合label参数，表示是否显示label后面的冒号，默认为true
+    /**
+     * 配合label参数，表示是否显示label后面的冒号，默认为true
+     */
     colon: PropTypes.bool,
 
-    // 设置表单项列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm
+    /**
+     * 设置表单项列宽相关属性，同AntdCol划分为24份宽度，优先级高于AntdForm
+     */
     wrapperCol: PropTypes.exact({
-        // 设置span宽度
+        /**
+         * 设置span宽度
+         */
         span: PropTypes.number,
 
-        // 设置offset平移宽度
+        /**
+         * 设置offset平移宽度
+         */
         offset: PropTypes.number,
 
-        // 同css中的flex属性
+        /**
+         * 同css中的flex属性
+         */
         flex: PropTypes.oneOfType([
             PropTypes.string,
             PropTypes.number
         ])
     }),
 
-    // 设置表单项标签内容
+    /**
+     * 设置表单项标签内容
+     */
     label: PropTypes.node,
 
-    // 设置表单项标签文本对齐方式，可选的为'left'与'right'，默认为'right'
+    /**
+     * 设置表单项标签文本对齐方式，可选的为'left'与'right'，默认为'right'
+     */
     labelAlign: PropTypes.oneOf(['left', 'right']),
 
-    // 在label后添加额外tooltip鼠标悬浮提示信息
+    /**
+     * 在label后添加额外tooltip鼠标悬浮提示信息
+     */
     tooltip: PropTypes.node,
 
-    // 设置表单项额外的提示信息
+    /**
+     * 设置表单项额外的提示信息
+     */
     extra: PropTypes.node,
 
-    // 设置校验状态，不设置时会根据设置的校验规则自动生成
+    /**
+     * 设置校验状态，不设置时会根据设置的校验规则自动生成
+     */
     validateStatus: PropTypes.oneOf([
         'success', 'warning', 'error', 'validating'
     ]),
@@ -92,11 +130,179 @@ AntdFormItem.propTypes = {
      */
     hasFeedback: PropTypes.bool,
 
-    // 设置与validateStatus状态一致的校验提示信息
+    /**
+     * 设置与validateStatus状态一致的校验提示信息
+     */
     help: PropTypes.node,
 
-    // 设置是否隐藏字段，隐藏后仍然会收集和校验字段，默认为false
+    /**
+     * 设置是否隐藏字段，隐藏后仍然会收集和校验字段，默认为false
+     */
     hidden: PropTypes.bool,
+
+    /**
+     * 设置默认验证字段的信息
+     */
+    messageVariables: PropTypes.object,
+
+    /**
+     * 为true时不带样式，作为纯字段控件使用，默认为false
+     */
+    noStyle: PropTypes.bool,
+
+    /**
+     * 设置当字段被删除时是否保留字段值，默认为true
+     */
+    preserve: PropTypes.bool,
+
+    /**
+     * 设置子元素默认值，如果与AntdForm的initialValues冲突则以AntdForm为准
+     */
+    initialValue: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]),
+
+    /**
+     * 设置字段名，支持数组
+     */
+    name: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number
+        ]))
+    ]),
+
+    /**
+     * 校验规则，设置字段的校验逻辑
+     */
+    rules: PropTypes.arrayOf(PropTypes.exact({
+        /**
+         * 仅在 type 为 array 类型时有效，用于指定数组元素的校验规则
+         */
+        defaultField: PropTypes.object,
+
+        /**
+         * 是否匹配枚举中的值（需要将 type 设置为 enum）
+         */
+        enum: PropTypes.any,
+
+        /**
+         * 仅在 type 为 array 或 object 类型时有效，用于指定子元素的校验规则
+         */
+        fields: PropTypes.any,
+
+        /**
+         * string 类型时为字符串长度；number 类型时为确定数字； array 类型时为数组长度
+         */
+        len: PropTypes.number,
+
+        /**
+         * 必须设置 type：string 类型为字符串最大长度；number 类型时为最大值；array 类型时为数组最大长度
+         */
+        max: PropTypes.number,
+
+        /**
+         * 错误信息，不设置时会通过模板自动生成
+         */
+        message: PropTypes.string,
+
+        /**
+         * 必须设置 type：string 类型为字符串最小长度；number 类型时为最小值；array 类型时为数组最小长度
+         */
+        min: PropTypes.number,
+
+        /**
+         * 正则表达式匹配
+         */
+        pattern: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.instanceOf(RegExp)
+        ]),
+
+        /**
+         * 是否为必选字段
+         */
+        required: PropTypes.bool,
+
+        /**
+         * 类型，常见有 string |number |boolean |url | email等
+         */
+        type: PropTypes.oneOf([
+            'string',
+            'number',
+            'boolean',
+            'method',
+            'regexp',
+            'integer',
+            'float',
+            'array',
+            'object',
+            'enum',
+            'date',
+            'url',
+            'hex',
+            'email',
+            'any'
+        ]),
+
+        /**
+         * 设置触发验证时机，可选值有onChange、onBlur、onFocus，默认为onChange，必须是AntdFormItem的validateTrigger的子集
+         */
+        validateTrigger: PropTypes.oneOfType([
+            PropTypes.oneOf([
+                'onChange',
+                'onBlur',
+                'onFocus'
+            ]),
+            PropTypes.arrayOf(PropTypes.oneOf([
+                'onChange',
+                'onBlur',
+                'onFocus'
+            ]))
+        ]),
+
+        /**
+         * 设置自定义校验js函数字符串
+         */
+        validator: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.func
+        ]),
+
+        /**
+         * 仅警告，不阻塞表单提交
+         */
+        warningOnly: PropTypes.bool,
+
+        /**
+         * 如果字段仅包含空格则校验不通过，只在 type: 'string' 时生效
+         */
+        whitespace: PropTypes.bool
+    })),
+
+    /**
+     * 设置触发验证时机，可选值有onChange、onBlur、onFocus，默认为onChange
+     */
+    validateTrigger: PropTypes.oneOfType([
+        PropTypes.oneOf([
+            'onChange',
+            'onBlur',
+            'onFocus'
+        ]),
+        PropTypes.arrayOf(PropTypes.oneOf([
+            'onChange',
+            'onBlur',
+            'onFocus'
+        ]))
+    ]),
+
+    /**
+     * 设置子节点的值的属性，默认为'value'
+     */
+    valuePropName: PropTypes.string,
 
     loading_state: PropTypes.shape({
         /**
@@ -122,9 +328,10 @@ AntdFormItem.propTypes = {
 
 // 设置默认参数
 AntdFormItem.defaultProps = {
-    required: false,
     hidden: false,
-    hasFeedback: false
+    hasFeedback: false,
+    noStyle: false,
+    preserve: true
 }
 
 export default AntdFormItem;

--- a/src/lib/fragments/dataEntry/AntdCheckbox.react.js
+++ b/src/lib/fragments/dataEntry/AntdCheckbox.react.js
@@ -1,10 +1,9 @@
 import React, { useContext, useEffect } from 'react';
 import { Checkbox } from 'antd';
 import { isString, isUndefined } from 'lodash';
+import { getBatchPropsValues } from '../utils';
 import useCss from '../../hooks/useCss';
 import PropsContext from '../../contexts/PropsContext';
-import FormContext from '../../contexts/FormContext';
-import useFormStore from '../../store/formStore';
 import { propTypes, defaultProps } from '../../components/dataEntry/AntdCheckbox.react';
 
 
@@ -16,7 +15,6 @@ const AntdCheckbox = (props) => {
         style,
         className,
         key,
-        name,
         label,
         disabled,
         autoFocus,
@@ -28,49 +26,44 @@ const AntdCheckbox = (props) => {
         persisted_props,
         persistence_type,
         loading_state,
-        batchPropsNames
+        batchPropsNames,
+        batchPropsValues,
+        batchFormValuesMode
     } = props;
 
     // 批属性监听
     useEffect(() => {
-        if (batchPropsNames && batchPropsNames.length !== 0) {
-            let _batchPropsValues = {};
-            for (let propName of batchPropsNames) {
-                _batchPropsValues[propName] = props[propName];
-            }
+        if (!batchFormValuesMode && batchPropsNames && batchPropsNames.length !== 0) {
             setProps({
-                batchPropsValues: _batchPropsValues
+                batchPropsValues: getBatchPropsValues(batchPropsNames, props)
             })
         }
     })
 
+    useEffect(() => {
+        if (batchFormValuesMode) {
+            setProps({ checked: batchPropsValues?.checked })
+        }
+    }, [batchPropsValues])
+
     const context = useContext(PropsContext)
-    const formId = useContext(FormContext)
 
-    const updateValues = useFormStore(state => state.updateValues)
-    const deleteItemValue = useFormStore(state => state.deleteItemValue)
+    const onBlur = () => {
+        props?.onBlur?.()
+    }
 
-    // 处理AntdForm表单值搜集功能
-    useEffect(() => {
-        // 若上文中存在有效表单id
-        if (formId && (name || id)) {
-            // 表单值更新
-            updateValues(formId, name || id, checked)
-        }
-    }, [checked, name, id])
-
-    // 处理组件卸载后，对应表单项值的清除
-    useEffect(() => {
-        return () => {
-            // 若上文中存在有效表单id
-            if (formId && (name || id)) {
-                // 表单值更新
-                deleteItemValue(formId, name || id)
-            }
-        }
-    }, [name, id])
+    const onFocus = () => {
+        props?.onFocus?.()
+    }
 
     const onChange = (e) => {
+        let _batchPropsValues = batchFormValuesMode ? getBatchPropsValues(batchPropsNames, props) : e.target.checked
+        if (batchFormValuesMode) {
+            if (batchPropsNames.includes('checked')) {
+                _batchPropsValues['checked'] = e.target.checked
+            }
+        }
+        props?.onChange?.(_batchPropsValues)
         if (!readOnly) {
             setProps({ checked: e.target.checked })
         }
@@ -87,6 +80,8 @@ const AntdCheckbox = (props) => {
             }
             style={style}
             key={key}
+            onBlur={onBlur}
+            onFocus={onFocus}
             onChange={onChange}
             disabled={
                 context && !isUndefined(context.componentDisabled) ?

--- a/src/lib/fragments/dataEntry/form/AntdForm.react.js
+++ b/src/lib/fragments/dataEntry/form/AntdForm.react.js
@@ -21,17 +21,39 @@ const AntdForm = (props) => {
         labelAlign,
         labelWrap,
         layout,
+        validateMessages,
+        validateTrigger,
+        values,
+        initialValues,
+        formValidateStatus,
+        submitForm,
+        submitFormClicks,
+        resetForm,
+        resetFormClicks,
         validateStatuses,
         helps,
         setProps,
         loading_state
     } = props;
 
-    // 订阅当前表单值搜集状态的变动
-    const _values = useFormStore((state) => state.values[id])
+    const [form] = Form.useForm();
 
     const updateValidateStatuses = useFormStore((state) => state.updateValidateStatuses)
     const updateHelps = useFormStore((state) => state.updateHelps)
+
+    const onFinish = (data) => {
+        setProps({ formValidateStatus: true })
+        setProps({ values: data })
+    }
+
+    const onFinishFailed = (data) => {
+        setProps({ formValidateStatus: false })
+        setProps({ values: data.values })
+    }
+
+    const onValuesChange = (changedValues, allValues) => {
+        setProps({ values: allValues })
+    }
 
     useEffect(() => {
         // 更新当前表单校验状态值
@@ -48,14 +70,36 @@ const AntdForm = (props) => {
     }, [helps])
 
     useEffect(() => {
-        setProps({ values: _values })
-    }, [_values])
+        form.setFieldsValue(values)
+    }, [values])
+
+    // 手动搜集表单检验状态
+    useEffect(() => {
+        if (submitForm) {
+            form.submit();
+            setProps({ submitFormClicks: submitFormClicks + 1 });
+            setProps({ submitForm: false });
+        }
+    }, [submitForm]);
+
+    // 手动重置表单项值及校验状态
+    useEffect(() => {
+        if (resetForm) {
+            form.resetFields();
+            setProps({ values: initialValues });
+            setProps({ resetFormClicks: resetFormClicks + 1 });
+            setProps({ formValidateStatus: null });
+            setProps({ resetForm: false });
+        }
+    }, [resetForm]);
+
 
     return (
         <FormContext.Provider
             value={id}
         >
             <Form id={id}
+                form={form}
                 className={
                     isString(className) ?
                         className :
@@ -69,6 +113,12 @@ const AntdForm = (props) => {
                 labelAlign={labelAlign}
                 labelWrap={labelWrap}
                 layout={layout}
+                validateMessages={validateMessages}
+                validateTrigger={validateTrigger}
+                initialValues={initialValues}
+                onFinish={onFinish}
+                onFinishFailed={onFinishFailed}
+                onValuesChange={onValuesChange}
                 data-dash-is-loading={
                     (loading_state && loading_state.is_loading) || undefined
                 }>

--- a/src/lib/fragments/dataEntry/form/AntdFormItem.react.js
+++ b/src/lib/fragments/dataEntry/form/AntdFormItem.react.js
@@ -26,12 +26,24 @@ const AntdFormItem = (props) => {
         extra,
         help,
         hidden,
+        initialValue,
+        name,
+        rules,
+        validateTrigger,
+        valuePropName,
         required,
         validateStatus,
         hasFeedback,
         setProps,
         loading_state
     } = props;
+
+    if (rules) {
+        rules.forEach(item => {
+            item.pattern = item.pattern ? new RegExp(item.pattern) : item.pattern;
+            item.validator = eval(item.validator);
+        });
+    }
 
     const formId = useContext(FormContext);
     const _validateStatus = useFormStore((state) => state.validateStatuses?.[formId]?.[label]);
@@ -56,6 +68,11 @@ const AntdFormItem = (props) => {
             help={help || _help}
             hasFeedback={hasFeedback}
             hidden={hidden}
+            initialValue={initialValue}
+            name={name}
+            rules={rules}
+            validateTrigger={validateTrigger}
+            valuePropName={valuePropName}
             required={required}
             validateStatus={validateStatus || _validateStatus}
             data-dash-is-loading={

--- a/src/lib/fragments/utils.js
+++ b/src/lib/fragments/utils.js
@@ -1,0 +1,10 @@
+const getBatchPropsValues = (batchPropsNames, props) => {
+    let _batchPropsValues = {};
+    for (let propName of batchPropsNames) {
+        _batchPropsValues[propName] = props[propName];
+    }
+    return _batchPropsValues
+}
+
+
+export { getBatchPropsValues }

--- a/usage.py
+++ b/usage.py
@@ -1,38 +1,225 @@
-import json
 import dash
 from dash import html
 import feffery_antd_components as fac
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, State, Output
+import os
+import json
+from flask import request
 
 app = dash.Dash(__name__)
 
 app.layout = html.Div(
-    [
-        fac.AntdSpace(
-            [
-                fac.AntdOTP(),
-                fac.AntdOTP(disabled=True),
-                fac.AntdOTP(length=8),
-                fac.AntdOTP(variant='filled'),
-                '回调示例：',
-                fac.AntdOTP(id='otp-demo'),
-                html.Pre(id='otp-demo-output'),
-            ],
-            direction='vertical',
-        )
-    ],
-    style={'padding': '50px 100px'},
+    fac.AntdSpace(
+        [
+            html.Pre(
+                '表单值'
+            ),
+            html.Pre(
+                id='demo-output'
+            ),
+            fac.AntdButton(
+                '加载初始数据',
+                id='load-form-data',
+                type='primary',
+            ),
+            fac.AntdForm(
+                [
+                    fac.AntdFormItem(
+                        fac.AntdSpace(
+                            [
+                                fac.AntdButton(
+                                    '提交',
+                                    id='submit-button',
+                                    type='primary',
+                                ),
+                                fac.AntdButton(
+                                    '重置',
+                                    id='reset-button',
+                                )
+                            ]
+                        )
+                    )
+                ] + [fac.AntdFormItem(
+                    fac.AntdInput(
+                        id=f'test-field{i}',
+                    ),
+                    name=f'测试字段{i}',
+                    label=f'测试字段{i}',
+                    validateTrigger=['onBlur' if i % 2 else 'onChange'],
+                    rules=[
+                        {
+                            'required': True,
+                            'message': '不满足手机号码校验',
+                            'validateTrigger': 'onBlur' if i % 2 else 'onChange',
+                            'pattern': '^(?:(?:\+|00)86)?1[3-9]\d{9}$'
+                        },
+                    ]
+                ) for i in range(3)] + [
+                    fac.AntdFormItem(
+                        fac.AntdInputNumber(
+                            id='test-AntdInputNumber',
+                            batchFormValuesMode=True,
+                            batchPropsNames=['value', 'disabled']
+                        ),
+                        name='AntdInputNumber',
+                        label='AntdInputNumber',
+                        validateTrigger='onBlur',
+                        valuePropName='batchPropsValues',
+                        rules=[
+                            {
+                                'required': True,
+                                'validator': '''
+                                    (_, value) => {
+                                        if (value?.value) {
+                                            return Promise.resolve();
+                                        }
+                                        return Promise.reject(new Error('请输入'));
+                                    }
+                                '''
+                            },
+                        ]
+                    ),
+                    fac.AntdFormItem(
+                        fac.AntdCheckbox(
+                            id='test-AntdCheckbox',
+                        ),
+                        name='AntdCheckbox',
+                        label='AntdCheckbox',
+                        validateTrigger='onBlur',
+                        valuePropName='checked',
+                        rules=[
+                            {
+                                'required': True,
+                                'type': 'boolean',
+                                'validateTrigger': 'onBlur',
+                                'message': '请勾选'
+                            },
+                        ]
+                    ),
+                    fac.AntdFormItem(
+                        fac.AntdTransfer(
+                            dataSource=[
+                                {
+                                    'key': i,
+                                    'title': f'选项{i}'
+                                }
+                                for i in range(1, 10)
+                            ],
+                            batchFormValuesMode=True,
+                            batchPropsNames=[
+                                'targetKeys', 'dataSource', 'moveDirection', 'moveKeys']
+                        ),
+                        name='AntdTransfer',
+                        label='AntdTransfer',
+                        validateTrigger='onChange',
+                        valuePropName='batchPropsValues',
+                        rules=[
+                            {
+                                'required': True,
+                                'validator': '''
+                                    (_, value) => {
+                                        if (value?.targetKeys.length > 0) {
+                                            return Promise.resolve();
+                                        }
+                                        return Promise.reject(new Error('请选择'));
+                                    }
+                                '''
+                            },
+                        ]
+                    ),
+                ],
+                id='demo-form',
+            ),
+        ],
+        direction='vertical',
+        style={
+            'width': '100%'
+        }
+    ),
+    style={
+        'padding': '50px 100px'
+    }
 )
 
 
 @app.callback(
-    Output('otp-demo-output', 'children'),
-    Input('otp-demo', 'value'),
+    Output('demo-form', 'values'),
+    Input('load-form-data', 'nClicks'),
+    prevent_initial_call=True
 )
-def demo_output(value):
+def initial_form_data(nClicks):
+    if nClicks:
+        return {
+            f'测试字段{i}': f'测试值{i}' for i in range(3)
+        }
+    return dash.no_update
+
+
+@app.callback(
+    Output('demo-form', 'submitForm'),
+    Input('submit-button', 'nClicks'),
+    prevent_initial_call=True
+)
+def manual_submit_form(nClicks):
+    if nClicks:
+        return True
+    return dash.no_update
+
+
+@app.callback(
+    Output('demo-form', 'resetForm'),
+    Input('reset-button', 'nClicks'),
+    prevent_initial_call=True
+)
+def manual_reset_form(nClicks):
+    if nClicks:
+        return True
+    return dash.no_update
+
+
+@app.callback(
+    Output('demo-output', 'children'),
+    Input('demo-form', 'submitFormClicks'),
+    [State('demo-form', 'values'),
+     State('demo-form', 'formValidateStatus')],
+    prevent_initial_call=True
+)
+def show_form_values(submitFormClicks, values, formValidateStatus):
+    # if formValidateStatus:
     return json.dumps(
-        dict(value=value), indent=4, ensure_ascii=False
+        values,
+        ensure_ascii=False,
+        indent=4
     )
+    # return '校验失败'
+
+
+@app.server.route('/upload/', methods=['POST'])
+def upload():
+    '''
+    构建文件上传服务
+    :return:
+    '''
+
+    # 获取上传id参数，用于指向保存路径
+    uploadId = request.values.get('uploadId')
+
+    # 获取上传的文件名称
+    filename = request.files['file'].filename
+
+    # 基于上传id，若本地不存在则会自动创建目录
+    try:
+        os.makedirs(os.path.join('caches', uploadId))
+    except FileExistsError:
+        pass
+
+    # 流式写出文件到指定目录
+    with open(os.path.join('caches', uploadId, filename), 'wb') as f:
+        # 流式写出大型文件，这里的10代表10MB
+        for chunk in iter(lambda: request.files['file'].read(1024 * 1024 * 10), b''):
+            f.write(chunk)
+
+    return {'filename': filename}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
以AntdCheckbox、AntdInput、AntdInputNumber、AntdTransfer为例，支持表单值搜集与受控（单值模式和批量属性值模式）、支持表单校验（单值模式和批量属性值模式）