### PR TITLE
fix: AntdTable editable columns with newsted rows

### DIFF
--- a/src/lib/fragments/AntdTable.react.js
+++ b/src/lib/fragments/AntdTable.react.js
@@ -103,6 +103,39 @@ const splitSummaryRowContents = (summaryRowContents, columnCount, blankColumns) 
     return summaryGroups;
 }
 
+const findItemByKey = (array, key) => {
+    let foundItem = null;
+
+    const search = (item) => {
+        if (item.key === key) {
+            foundItem = item;
+            return true;
+        }
+        return Array.isArray(item.children) && item.children.some(search);
+    };
+
+    array.some(search);
+    return foundItem;
+};
+
+const replaceItemByKey = (array, key, replacement) => {
+    for (let i = 0; i < array.length; i++) {
+        const item = array[i];
+        if (item && item.key === key) {
+            array.splice(i, 1, replacement);
+            return true;
+        }
+
+        if (item && Array.isArray(item.children)) {
+            if (replaceItemByKey(item.children, key, replacement)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 // 定义不触发重绘的参数数组
 const preventUpdateProps = [
     'recentlyMouseEnterColumnDataIndex',
@@ -476,8 +509,7 @@ class AntdTable extends Component {
             const handleSave = (row, setProps, dataSource, setDataSource) => {
 
                 const newData = [...dataSource];
-                const index = newData.findIndex((item) => row.key === item.key);
-                const item = newData[index];
+                const item = findItemByKey(newData, row.key)
 
                 const rowColumns = Object.getOwnPropertyNames(row)
 
@@ -505,7 +537,7 @@ class AntdTable extends Component {
                     }
                 }
 
-                newData.splice(index, 1, { ...item, ...row });
+                replaceItemByKey(newData, row.key, { ...item, ...row })
 
                 setDataSource(newData);
 


### PR DESCRIPTION
Hi. I am an active user of your repository.
I know that in the future you want to refactor the AntdTable component, but maybe this is the first step.

I'm closely using components in conjunction with a tree-like data structure and ran into a problem

When a tree data structure is used and columns editble = True, an error occurs when trying to modify nested rows.
I'm new to js, but this is my vision of an interim solution.

MRE:
```python
import json

import dash
from dash import Input, Output, html

import feffery_antd_components as fac

app = dash.Dash(__name__)

table = fac.AntdTable(
    id='table-click-event-demo',
    columns=[
        {
            'title': f'Column {i}',
            'dataIndex': f'column-{i}',
            'width': 'calc(100% / 3)',
            'editable': True,
        }
        for i in range(1, 4)
    ],
    data=[
        {
            'key': f'row-{i}',
            'column-1': '第一层',
            'column-2': '第一层',
            'column-3': '第一层',
            'children': [
                {
                    'key': f'row-{i}{j}',
                    'column-1': '第二层',
                    'column-2': '第二层',
                    'column-3': '第二层',
                    'children': [
                        {
                            'key': f'row-{i}{j}{k}',
                            'column-1': '第二层',
                            'column-2': '第二层',
                            'column-3': '第二层',
                        }
                        for k in range(3)
                    ],
                }
                for j in range(3)
            ],
        }
        for i in range(3)
    ],
    bordered=True,
    style={'width': '500px', 'height': '100%'},
)

app.layout = html.Div(
    fac.AntdSpace(
        [
            table,
            html.Pre(id='table-click-event-demo-output'),
        ],
        align='center',
        style={
            'width': '100%',
            'height': '100%',
            'justifyContent': 'center',
            'flexDirection': 'column',
        },
    ),
    style={'width': '100%', 'height': '100%'},
)


@app.callback(
    Output('table-click-event-demo-output', 'children'),
    Input('table-click-event-demo', 'nClicksCell'),
    Input('table-click-event-demo', 'recentlyChangedRow'),
    prevent_initial_call=True,
)
def table_click_event_demo(nClicksCell, recentlyChangedRow):
    return json.dumps(
        dict(
            nClicksCell=nClicksCell,
            recentlyChangedRow=recentlyChangedRow,
        ),
        indent=4,
        ensure_ascii=False,
    )


if __name__ == '__main__':
    app.run(debug=True)

```