### PR TITLE
Feat/add option for sticky table header based on css selectors

### DIFF
--- a/feffery_antd_components/AntdTable.py
+++ b/feffery_antd_components/AntdTable.py
@@ -576,6 +576,9 @@ Keyword arguments:
 
     `sticky` is a boolean | dict with keys:
 
+    - belowSelector (string | list of strings; optional):
+        粘贴在其下方的元素的 CSS 选择器.
+
     - offsetHeader (number; optional):
         粘性表头竖直方向上的像素偏移量.
 
@@ -1170,6 +1173,7 @@ Keyword arguments:
     Sticky = TypedDict(
         "Sticky",
             {
+            "belowSelector": NotRequired[typing.Union[str, typing.Sequence[str]]],
             "offsetHeader": NotRequired[NumberType],
             "offsetScroll": NotRequired[NumberType]
         }

--- a/src/lib/components/dataDisplay/AntdTable.react.js
+++ b/src/lib/components/dataDisplay/AntdTable.react.js
@@ -1087,6 +1087,13 @@ AntdTable.propTypes = {
         PropTypes.bool,
         PropTypes.exact({
             /**
+             * 粘贴在其下方的元素的 CSS 选择器
+             */
+            belowSelector: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.arrayOf(PropTypes.string)
+            ]),
+            /**
              * 粘性表头竖直方向上的像素偏移量
              */
             offsetHeader: PropTypes.number,

--- a/src/lib/fragments/AntdTable.react.js
+++ b/src/lib/fragments/AntdTable.react.js
@@ -48,6 +48,7 @@ import { isNumber, isEqual, isString, isBoolean, isEmpty, omitBy } from 'lodash'
 import { pickBy } from 'ramda';
 import { str2Locale, locale2text } from '../components/locales.react';
 import { useLoading } from '../components/utils';
+import useStickyOffset from '../hooks/useStickyOffset';
 // 上下文
 import PropsContext from '../contexts/PropsContext';
 // 参数类型
@@ -231,6 +232,18 @@ const AntdTable = (props) => {
 
     const [searchText, setSearchText] = useState('');
     const [searchedColumn, setSearchedColumn] = useState('');
+
+    const stickyObj = (sticky && typeof sticky === 'object') ? sticky : {};
+    const belowSelector = stickyObj.belowSelector ?? undefined;
+    const offsetHeader = Number(stickyObj.offsetHeader || 0);
+    const autoMeasuredOffset = belowSelector ? useStickyOffset({ selector: belowSelector, extra: offsetHeader }) : offsetHeader;
+    const { belowSelector: _rm1,
+            offsetHeader: _rm2,
+            ...stickyRest
+        } = stickyObj;
+    const computedSticky = sticky === true || belowSelector || (sticky && typeof sticky === 'object')
+                            ? { ...stickyRest, offsetHeader: autoMeasuredOffset }
+                            : undefined;
 
     const onPageChange = (pagination, filter, sorter, currentData) => {
 
@@ -2004,7 +2017,7 @@ const AntdTable = (props) => {
                 tableLayout={tableLayout}
                 size={size}
                 rowSelection={rowSelection}
-                sticky={sticky}
+                sticky={computedSticky}
                 pagination={
                     // 确保pagination=false生效
                     pagination &&

--- a/src/lib/hooks/useStickyOffset.js
+++ b/src/lib/hooks/useStickyOffset.js
@@ -1,0 +1,115 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+function resolveNodes(selector) {
+  const sels = Array.isArray(selector) ? selector : [selector];
+  const nodes = [];
+  if (typeof document === 'undefined') return nodes;
+  for (const sel of sels) {
+    if (!sel) continue;
+    const first = document.querySelector(sel);
+    if (first) nodes.push(first);
+  }
+  return nodes;
+}
+
+function getNodesHeight(nodes) {
+  // include borders + padding; exclude margins
+  return nodes.reduce((acc, n) => acc + n.getBoundingClientRect().height, 0);
+}
+
+/**
+ * Returns a live pixel offset equal to the total height of the element(s)
+ * matched by `selector`. Updates on resize, content changes, and CSS class
+ * toggles (useful for Collapse animations).
+ *
+ * Usage:
+ *   useStickyOffset('.header')
+ *   useStickyOffset({ selector: ['.topbar', '.filters'], extra: 8 })
+ */
+export default function useStickyOffset(selectorOrOptions, extra = 0) {
+  const isObj =
+    selectorOrOptions &&
+    typeof selectorOrOptions === 'object' &&
+    !Array.isArray(selectorOrOptions);
+
+  const selector = isObj
+    ? (selectorOrOptions.selector ?? selectorOrOptions.belowSelector ?? null)
+    : selectorOrOptions;
+
+  // allow both `{ extra }` in options and the 2nd positional arg
+  const extraAdd =
+    (isObj ? Number(selectorOrOptions.extra || 0) : Number(extra || 0)) || 0;
+
+  const [offset, setOffset] = useState(0);
+  const rafRef = useRef(null);
+  const nodesRef = useRef([]);
+
+  const update = () => {
+    const nodes = nodesRef.current;
+    const h = nodes.length ? getNodesHeight(nodes) : 0;
+    // 1px threshold avoids micro-flutters during transitions
+    setOffset((prev) => {
+      const next = h + extraAdd;
+      return Math.abs(prev - next) >= 1 ? next : prev;
+    });
+  };
+
+  // use layout effect on client so first paint has correct offset
+  const useLE = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+  useLE(() => {
+    if (!selector) {
+      setOffset(extraAdd);
+      return;
+    }
+    nodesRef.current = resolveNodes(selector);
+
+    // initial measure
+    update();
+
+    // observe size changes
+    const ros = [];
+    if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+      for (const n of nodesRef.current) {
+        const ro = new ResizeObserver(() => update());
+        ro.observe(n);
+        ros.push(ro);
+      }
+    }
+
+    // observe attribute/class changes that may affect height
+    const mos = [];
+    if (typeof window !== 'undefined' && 'MutationObserver' in window) {
+      for (const n of nodesRef.current) {
+        const mo = new MutationObserver(() => {
+          if (rafRef.current) cancelAnimationFrame(rafRef.current);
+          rafRef.current = requestAnimationFrame(update);
+        });
+        mo.observe(n, {
+          attributes: true,
+          attributeFilter: ['style', 'class', 'data-open', 'aria-expanded'],
+          childList: true,
+          subtree: true
+        });
+        mos.push(mo);
+      }
+    }
+
+    const onWin = () => update();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', onWin);
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('resize', onWin);
+      }
+      ros.forEach((ro) => ro.disconnect());
+      mos.forEach((mo) => mo.disconnect());
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+    // stringify option to capture selector arrays etc.
+  }, [JSON.stringify(selector), extraAdd]);
+
+  return offset;
+}

--- a/tests/dataDisplay/AntdTable/feat_sticky_header.py
+++ b/tests/dataDisplay/AntdTable/feat_sticky_header.py
@@ -1,0 +1,81 @@
+if True:
+    import sys
+
+    sys.path.append("../../../")
+    import dash
+    from dash import html
+
+    import feffery_antd_components as fac
+
+app = dash.Dash(__name__)
+
+app.layout = html.Div(
+    [
+        # ---- sticky top section whose height can change (collapse) ----
+        html.Div(
+            fac.AntdAccordion(
+                items=[
+                    {
+                        "title": f"手风琴项示例{i}",
+                        "key": i,
+                        "children": fac.AntdText(f"手风琴项示例{i}"),
+                    }
+                    for i in range(1, 6)
+                ]
+            ),
+            # this outer wrapper is what the hook observes
+            className="filters-shell",
+            style={
+                "position": "sticky",
+                "top": 0,
+                "zIndex": 20,
+                "background": "white",
+                "borderBottom": "1px solid #f0f0f0",
+            },
+        ),
+        html.Br(),
+        fac.AntdTable(
+            columns=[
+                {"title": f"Field {i}", "dataIndex": f"Field {i}"} for i in range(5)
+            ],
+            data=[
+                {**{f"Field {j}": i for j in range(5)}, "key": f"row-{i}"}
+                for i in range(60)
+            ],
+            bordered=True,
+            size="middle",
+            className="sticky-table",
+            sticky={"belowSelector": ".filters-shell"},
+            pagination={"pageSize": 100, "position": "bottomCenter"},
+            expandedRowKeyToContent=[
+                {
+                    "key": f"row-{i}",
+                    "content": fac.AntdTable(
+                        columns=[
+                            {"title": f"Nested {i}", "dataIndex": f"Field {i}"}
+                            for i in range(5)
+                        ],
+                        data=[
+                            {**{f"Field {j}": i for j in range(5)}, "key": f"row-{i}"}
+                            for i in range(60)
+                        ],
+                        bordered=True,
+                        size="middle",
+                        sticky={
+                            "belowSelector": [
+                                ".filters-shell",
+                                ".sticky-table .ant-table-header.ant-table-sticky-holder",
+                            ],
+                        },
+                        pagination={"pageSize": 100, "position": "bottomCenter"},
+                    ),
+                }
+                for i in range(60)
+            ],
+        ),
+    ],
+    style={"padding": 24, "maxWidth": 1000, "margin": "0 auto"},
+)
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
This PR adds the possibility to use a CSS selector to stick the table header under. This is pretty helpful when having a dynamic areas above the table. It is also helpfull to stick nested tables headers if needed.

https://github.com/user-attachments/assets/e25332fd-4b89-4739-92cd-2849a68f51af

