### PR TITLE
bump antd to include table fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@formily/react": "^2.3.1",
         "@plotly/webpack-dash-dynamic-import": "^1.3.0",
         "ahooks": "^3.7.0",
-        "antd": "^5.27.1",
+        "antd": "^5.27.3",
         "antd-img-crop": "^4.2.3",
         "color": "^4.2.3",
         "dayjs": "^1.11.13",


### PR DESCRIPTION
The new Antd release includes important bug fixes especially for table headers, this PR bumps the antd version to 5.27.3